### PR TITLE
Annotate bug in data reading.

### DIFF
--- a/Run_Pathifier.R
+++ b/Run_Pathifier.R
@@ -15,7 +15,7 @@ exp.matrix <- read.delim(file =file.choose(), as.is = T, row.names = 1)
 
 # Loading Genesets annotation
 gene_sets <- as.matrix(read.delim(file = file.choose(),
-                       header = F, sep = "\t", as.is = T))
+                       header = F, sep = "\t", as.is = T))  # BUG: The first line must be the longest!
 
 #  Generate a list that contains genes in genesets
 gs <- list()


### PR DESCRIPTION
This is known to read at least one data file erroneously in a file where

awk '{print NF}' file
238
26
5
7
5
2
8
53
82
4
205
2
5
5
339
50
39
3
404
326
372
